### PR TITLE
Clear reference grid before loading a file

### DIFF
--- a/VirtualRef/VirtualRef.cpp
+++ b/VirtualRef/VirtualRef.cpp
@@ -177,6 +177,7 @@ void VirtualRef::loadCustomParametersFromXml()
 		setGlobalGain(globGain);
 	}
 
+    refMat->clear();
 	forEachXmlChildElementWithTagName(*parametersAsXml,	channelsXml, "REFERENCES")
 	{
 		forEachXmlChildElementWithTagName(*channelsXml,	channelXml, "CHANNEL")


### PR DESCRIPTION
This makes sure the reference grid is clear before loading XML, whether from a saved signal chain or from a file saved from the plugin directly. This way, you don't get unexpected mixtures of different referencing schemes if you load a new scheme with some reference channels already selected.